### PR TITLE
Typo in servers.ini

### DIFF
--- a/servers.ini
+++ b/servers.ini
@@ -116,8 +116,8 @@
             "url": "http://bitclockers.com"
         }, 
         {
-            "host": "bitcoin.lc", 
-            "name": "Bitcoin.lc", 
+            "host": "bitcoins.lc", 
+            "name": "Bitcoins.lc", 
             "port": 8080, 
             "url": "http://www.bitcoins.lc"
         }, 


### PR DESCRIPTION
Changed a typo in servers.ini to actually contain the correct domain for our pool (Bitcoins.lc)
Bitcoin.lc is owned by someone else and stopped working just recently cause of the owner changing DNS-records.

Bitcoins.lc is the actual domain that should be used for now.
Please merge this asap and publish releases for it.

Regards, Jim
Bit LC Inc.
