### PR TITLE
Bitcoins.lc goes Bitlc.net

### DIFF
--- a/servers.ini
+++ b/servers.ini
@@ -116,10 +116,10 @@
             "url": "http://bitclockers.com"
         }, 
         {
-            "host": "bitcoins.lc", 
-            "name": "Bitcoins.lc", 
-            "port": 8080, 
-            "url": "http://www.bitcoins.lc"
+            "host": "pool.bitlc.net", 
+            "name": "Bitlc.net", 
+            "port": 80, 
+            "url": "http://www.bitlc.net"
         }, 
         {
             "host": "rr.btcmp.com", 


### PR DESCRIPTION
Changed server for bitcoins.lc due to domain and pool-address change to bitlc.net.
Also updated port to tcp/80 which is preferred.
