### PR TITLE
Fix Regexp for CGMiner

### DIFF
--- a/guiminer.py
+++ b/guiminer.py
@@ -511,7 +511,7 @@ class CgListenerThread(MinerListenerThread):
             lambda _: UpdateAcceptedEvent(accepted=True)),
         (r"Rejected .* GPU \d+ thread \d+",
             lambda _: UpdateAcceptedEvent(accepted=False)),
-        (r"\(\d+s\):(\d+)\.?(\d*) .* Mh/s", lambda match:
+        (r"\(avg\):(\d+)\.?(\d*)Mh/s", lambda match:
             UpdateHashRateEvent(rate=float(match.group(1) + '.' + match.group(2)) * 1000)),
         (r"^GPU\s*\d+",
             lambda _: None), # Just ignore lines like these


### PR DESCRIPTION
Hello,
the CGListener doesn't work the way it's currently coded:

```
(r"\(\d+s\):(\d+)\.?(\d*) .* Mh/s", lambda match:
```

This regexp says that there is one number, which may optionally be a decimal.
This number is followed by at least one space, then optionally more text and then another space and then the Unit (Mh/s). That means at least two spaces between number and Unit are required for this regexp to match.However the current version of CGMiner has NOTHING (not a single space) between number and unit. Instead the Unit and the number form a single word.

Here's a fixed Regexp that works for the current version.
If they ever fix their log syntax in CGMiner, one could take the space that shoul be between number and unit into account.
However it would be very strange if they added extra characters there. That should be handled as an exceptional situation (i.e. the regexp should not match and the output should be written to the console in that case)

```
(r"\(avg\):(\d+)\.?(\d*)Mh/s", lambda match:
```
